### PR TITLE
Cache HTTP connection for Service.pm

### DIFF
--- a/lib/Net/Fritz/Box.pm
+++ b/lib/Net/Fritz/Box.pm
@@ -112,7 +112,8 @@ sub _build__ua {
     # I have one machine that needs it and another that doesn't.
     $ENV{HTTPS_DEBUG} = 1;
     
-    my $ua = LWP::UserAgent->new();
+    my $ua = LWP::UserAgent->new(keep_alive => 1);
+    $ua->conn_cache({total_capacity => 4});
     # disable SSL certificate checks, Fritz!Box has no verifiable SSL certificate
     $ua->ssl_opts(verify_hostname => 0 ,SSL_verify_mode => 0x00);
     

--- a/lib/Net/Fritz/Service.pm
+++ b/lib/Net/Fritz/Service.pm
@@ -260,10 +260,12 @@ sub call {
     my $url = $self->fritz->upnp_url . $self->controlURL;
 
     my $soap = SOAP::Lite->new(
-	proxy    => [ $url, ssl_opts => $self->fritz->_sslopts ],
+	proxy    => [ $url, ssl_opts => $self->fritz->_sslopts, keep_alive => 1, ],
 	uri      => $self->serviceType,
 	readable => 1, # TODO: remove this
 	);
+    # Keep up to 4 connections open
+    $soap->transport->conn_cache({ total_capacity => 4 });
 
     # expect the call to need authentication, so prepare an initial request
     my $auth = $self->_get_initial_auth;

--- a/lib/Net/Fritz/Service.pm
+++ b/lib/Net/Fritz/Service.pm
@@ -185,7 +185,7 @@ sub _build_eventSubURL {
     return $self->_build_an_attribute('eventSubURL');
 }
 
-=head2
+=head2 SCPDURL
 
 The I<SCPDURL> (URL string) of the SCPD file of this service where
 most of the other attributes are read from.


### PR DESCRIPTION
This small change makes the communication with a Fritz!Box much faster by enabling HTTP Keep-Alive. This makes writing ~230 contacts go from 255 seconds down to 136 seconds.

A simple status query listing all phonebooks and their contents goes from 9 seconds to 6 seconds.

In the long run, maybe a common way to specify options for LWP::UserAgent-style clients might be nicer, but I currently can't think of other options of interest.