### PR TITLE
Force all data into the SOAP "string" type

### DIFF
--- a/lib/Net/Fritz/Service.pm
+++ b/lib/Net/Fritz/Service.pm
@@ -254,7 +254,7 @@ sub call {
 
     my @args;
     foreach my $arg (keys %call_args) {
-	push @args, SOAP::Data->name($arg)->value($call_args{$arg});
+	push @args, SOAP::Data->name($arg)->value($call_args{$arg})->type('string');
     }
 
     my $url = $self->fritz->upnp_url . $self->controlURL;


### PR DESCRIPTION
This prevents SOAP::Lite from guessing UTF-8 strings as base64Binary,
which the FritzBox doesn't understand.

This doesn't completely help with sending UTF-8 encoded phone book entries
to the FritzBox, but it is certainly better than the magic that SOAP::Lite
tries to employ for guessing the parameter type.